### PR TITLE
chore: fix TS1205 and TS1371 error

### DIFF
--- a/application.ts
+++ b/application.ts
@@ -1,4 +1,4 @@
-import { Chrome } from "./chrome.ts";
+import type { Chrome } from "./chrome.ts";
 
 export interface Application {
   load(url: string): Promise<void>;

--- a/deps.ts
+++ b/deps.ts
@@ -6,8 +6,8 @@ export { decode, encode } from "https://deno.land/std@v0.70.0/encoding/utf8.ts";
 export { encode as encodeToBase64 } from "https://deno.land/std@v0.70.0/encoding/base64.ts";
 export {
   deferred,
-  Deferred,
 } from "https://deno.land/std@v0.70.0/async/deferred.ts";
+export type { Deferred } from "https://deno.land/std@v0.70.0/async/deferred.ts";
 export { sprintf } from "https://deno.land/std@v0.70.0/fmt/printf.ts";
 export {
   assert,


### PR DESCRIPTION
When using carol with `--unstable` flag, The following error occurs:
```shell
$ deno test -A --coverage --unstable
Debugger listening on ws://127.0.0.1:9229/ws/a8271eb7-e619-443b-aaad-a18d1d9fbf34
Check file:///home/uki00a/ghq/github.com/uki00a/carol/.deno.test.ts
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  Deferred,
  ~~~~~~~~
    at file:///home/uki00a/ghq/github.com/uki00a/carol/deps.ts:9:3

TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { Chrome } from "./chrome.ts";
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at file:///home/uki00a/ghq/github.com/uki00a/carol/application.ts:1:1

Found 2 errors.
```
This PR fixes those errors.