### PR TITLE
compatibility with deno 1.6 and  warning fix

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,21 +1,21 @@
-export { exists } from "https://deno.land/std@v0.70.0/fs/exists.ts";
-export { dirname, join } from "https://deno.land/std@v0.70.0/path/mod.ts";
-export { BufReader } from "https://deno.land/std@v0.70.0/io/bufio.ts";
-export { concat } from "https://deno.land/std@v0.70.0/bytes/mod.ts";
-export { decode, encode } from "https://deno.land/std@v0.70.0/encoding/utf8.ts";
-export { encode as encodeToBase64 } from "https://deno.land/std@v0.70.0/encoding/base64.ts";
+export { exists } from "https://deno.land/std@0.70.0/fs/exists.ts";
+export { dirname, join } from "https://deno.land/std@0.70.0/path/mod.ts";
+export { BufReader } from "https://deno.land/std@0.70.0/io/bufio.ts";
+export { concat } from "https://deno.land/std@0.70.0/bytes/mod.ts";
+export { decode, encode } from "https://deno.land/std@0.70.0/encoding/utf8.ts";
+export { encode as encodeToBase64 } from "https://deno.land/std@0.70.0/encoding/base64.ts";
 export {
   deferred,
-} from "https://deno.land/std@v0.70.0/async/deferred.ts";
-export type { Deferred } from "https://deno.land/std@v0.70.0/async/deferred.ts";
-export { sprintf } from "https://deno.land/std@v0.70.0/fmt/printf.ts";
+} from "https://deno.land/std@0.70.0/async/deferred.ts";
+export type { Deferred } from "https://deno.land/std@0.70.0/async/deferred.ts";
+export { sprintf } from "https://deno.land/std@0.70.0/fmt/printf.ts";
 export {
   assert,
   assertEquals,
   assertStrictEquals,
   assertThrowsAsync,
   fail,
-} from "https://deno.land/std@v0.70.0/testing/asserts.ts";
+} from "https://deno.land/std@0.70.0/testing/asserts.ts";
 // TODO Use window.WebSocket
 export {
   connectWebSocket,


### PR DESCRIPTION
fix about : 
```Warning std versions prefixed with 'v' were deprecated recently.```